### PR TITLE
Wire up a basic confirm dialog

### DIFF
--- a/DIM/WebView.swift
+++ b/DIM/WebView.swift
@@ -246,4 +246,42 @@ extension ViewController: WKUIDelegate {
         // Display the NSAlert
         present(alert, animated: true, completion: nil)
     }
+    
+    func webView(_ webView: WKWebView,
+        runJavaScriptConfirmPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping (Bool) -> Void) {
+
+        // Set the message as the UIAlertController message
+        let alert = UIAlertController(
+            title: nil,
+            message: message,
+            preferredStyle: .alert
+        )
+        
+        // Add a confirmation action “Cancel”
+        let cancelAction = UIAlertAction(
+            title: "Cancel",
+            style: .cancel,
+            handler: { _ in
+                // Call completionHandler
+                completionHandler(false)
+            }
+        )
+        
+        // Add a confirmation action “OK”
+        let okAction = UIAlertAction(
+            title: "OK",
+            style: .default,
+            handler: { _ in
+                // Call completionHandler
+                completionHandler(true)
+            }
+        )
+        alert.addAction(cancelAction)
+        alert.addAction(okAction)
+
+        // Display the NSAlert
+        present(alert, animated: true, completion: nil)
+    }
 }


### PR DESCRIPTION
Seems `alert()` was working, but `confirm()` was not. Will upstream. This resolves #3 

https://user-images.githubusercontent.com/424158/147423063-c9e860f5-21ed-427a-8bea-5f5c0a305a4c.mov

