### PR TITLE
Add menu and remove UA mod for macOS

### DIFF
--- a/DIM.xcodeproj/project.pbxproj
+++ b/DIM.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		595F23AF25CEFBFE0053416C /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595F23A425CEFBFE0053416C /* WebView.swift */; };
 		CDC0FE292388222C002C8D56 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CDC0FE252388222B002C8D56 /* Main.storyboard */; };
 		CDC0FE2A2388222C002C8D56 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CDC0FE272388222B002C8D56 /* LaunchScreen.storyboard */; };
+		D5FD6533277A5E5C00F3BE31 /* Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = D5FD6532277A5E5C00F3BE31 /* Dynamic */; };
 		E1E260C850014D6B34B487B0 /* Pods_DIM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE9D7FFB2FBE6EEBCA807B6A /* Pods_DIM.framework */; };
 /* End PBXBuildFile section */
 
@@ -47,6 +48,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D5FD6533277A5E5C00F3BE31 /* Dynamic in Frameworks */,
 				E1E260C850014D6B34B487B0 /* Pods_DIM.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -111,6 +113,9 @@
 			dependencies = (
 			);
 			name = DIM;
+			packageProductDependencies = (
+				D5FD6532277A5E5C00F3BE31 /* Dynamic */,
+			);
 			productName = DIM;
 			productReference = 59333BAA25CFF706003392A4 /* DIM.app */;
 			productType = "com.apple.product-type.application";
@@ -140,6 +145,9 @@
 				Base,
 			);
 			mainGroup = CD89F880237E9D9200C436A1;
+			packageReferences = (
+				D5FD6531277A5E5C00F3BE31 /* XCRemoteSwiftPackageReference "Dynamic" */,
+			);
 			productRefGroup = CD89F880237E9D9200C436A1;
 			projectDirPath = "";
 			projectRoot = "";
@@ -439,6 +447,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		D5FD6531277A5E5C00F3BE31 /* XCRemoteSwiftPackageReference "Dynamic" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mhdhejazi/Dynamic.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		D5FD6532277A5E5C00F3BE31 /* Dynamic */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D5FD6531277A5E5C00F3BE31 /* XCRemoteSwiftPackageReference "Dynamic" */;
+			productName = Dynamic;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = CD89F881237E9D9200C436A1 /* Project object */;
 }

--- a/DIM.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DIM.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Dynamic",
+        "repositoryURL": "https://github.com/mhdhejazi/Dynamic.git",
+        "state": {
+          "branch": "master",
+          "revision": "772883073d044bc754d401cabb6574624eb3778f",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/DIM/AppDelegate.swift
+++ b/DIM/AppDelegate.swift
@@ -1,3 +1,4 @@
+import Dynamic
 import UIKit
 import FirebaseCore
 import FirebaseMessaging
@@ -76,6 +77,46 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         print("Unable to register for remote notifications: \(error.localizedDescription)")
       }
 
+        override func buildMenu(with builder: UIMenuBuilder) {
+            super.buildMenu(with: builder)
+
+            builder.remove(menu: .services)
+            builder.remove(menu: .hide)
+            builder.remove(menu: .window)
+            builder.remove(menu: .file)
+            builder.remove(menu: .edit)
+            builder.remove(menu: .format)
+            builder.remove(menu: .view)
+            builder.remove(menu: .help)
+            
+            builder.insertSibling(UIMenu(
+                title: "",
+                options: .displayInline,
+                children: [
+                    UIKeyCommand(title: "Preferences...",
+                                 action: #selector(openPreferences),
+                                 input: ",",
+                                 modifierFlags: .command),
+                    UICommand(title: "Usage guide",
+                              action: #selector(openWiki)),
+                    UICommand(title: "@ThisIsDIM",
+                              action: #selector(openTwitter))]
+            ), afterMenu: .about)
+        }
+        
+    @objc func openPreferences() {
+        DIM.webView.load(URLRequest(url: URL(string:"https://app.destinyitemmanager.com/settings")!));
+    }
+    @objc func openWiki() {
+        let url = URL(string: "https://destinyitemmanager.fandom.com/wiki/Category:User_Guide")!
+        Dynamic.NSWorkspace.sharedWorkspace.openURL(url)
+    }
+    @objc func openTwitter() {
+        let url = URL(string: "https://twitter.com/ThisIsDIM")!
+        Dynamic.NSWorkspace.sharedWorkspace.openURL(url)
+    }
+
+
       // This function is added here only for debugging purposes, and can be removed if swizzling is enabled.
       // If swizzling is disabled then this function must be implemented so that the APNs token can be paired to
       // the FCM registration token.
@@ -142,3 +183,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       }
       // [END refresh_token]
     }
+

--- a/DIM/Info.plist
+++ b/DIM/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>LSApplicationCategoryType</key>
-	<string>public.app-category.entertainment</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
@@ -37,6 +35,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.entertainment</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/DIM/WebView.swift
+++ b/DIM/WebView.swift
@@ -23,9 +23,11 @@ func createWebView(container: UIView, WKSMH: WKScriptMessageHandler, WKND: WKNav
     config.allowsInlineMediaPlayback = true
     config.preferences.setValue(true, forKey: "standalone")
 
+    #if !targetEnvironment(macCatalyst)
     // Append the safari UA to the end so that Stadia (Google login) works.
     // https://github.com/pwa-builder/pwabuilder-ios/issues/30
     config.applicationNameForUserAgent = "Safari/604.1"
+    #endif
     
 
     let webView = WKWebView(frame: calcWebviewFrame(webviewView: container, toolbarView: nil), configuration: config)


### PR DESCRIPTION
Kept the menu simple -- `cmd + ,` will load the settings page, rest just opens the links in default browser

<img width="896" alt="Screen Shot 2021-12-27 at 2 11 06 PM" src="https://user-images.githubusercontent.com/424158/147510312-fe5237c3-0bf0-4ce6-a0f0-6b04386713b7.png">
